### PR TITLE
doc: update article link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ```
 
 ## Options
-See [component-level caching](http://ssr.vuejs.org/en/caching.html#component-level-caching) for mor information.
+See [component-level caching](https://v2.ssr.vuejs.org/guide/caching.html#component-level-caching) for mor information.
 
 ### `max`
 - default: `10000`


### PR DESCRIPTION
## describe
"component-level caching" article link is outdated  

same as https://github.com/nuxt/modules/blob/babaafef2c69672bd2b0309b6219a0df38f43dc8/modules/component-cache.yml#L8